### PR TITLE
Add endpoint-based site page discovery and management UI

### DIFF
--- a/src/VisualAcademy/VisualAcademy/Controllers/SitePagesController.cs
+++ b/src/VisualAcademy/VisualAcademy/Controllers/SitePagesController.cs
@@ -1,0 +1,34 @@
+﻿using Azunt.Web.Data;
+using Azunt.Web.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Azunt.Web.Controllers;
+
+public class SitePagesController : Controller
+{
+    private readonly ApplicationDbContext _context;
+    private readonly SitePageRouteSyncService _sync;
+
+    public SitePagesController(
+        ApplicationDbContext context,
+        SitePageRouteSyncService sync)
+    {
+        _context = context;
+        _sync = sync;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        return View(await _context.SitePages
+            .OrderBy(x => x.SortOrder)
+            .ToListAsync());
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Sync()
+    {
+        await _sync.SyncAsync();
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/src/VisualAcademy/VisualAcademy/Data/ApplicationDbContext.cs
+++ b/src/VisualAcademy/VisualAcademy/Data/ApplicationDbContext.cs
@@ -24,6 +24,8 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
 
     public DbSet<KnownUser> KnownUsers { get; set; }
 
+    public DbSet<SitePage> SitePages => Set<SitePage>();
+
     /// <summary>
     /// 모델(테이블)이 생성될 때 처음 실행 
     /// </summary>

--- a/src/VisualAcademy/VisualAcademy/Data/ApplicationDbContext.cs
+++ b/src/VisualAcademy/VisualAcademy/Data/ApplicationDbContext.cs
@@ -52,6 +52,16 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         //);
 
         builder.Entity<KnownUser>().ToTable("KnownUsers");
+
+        builder.Entity<SitePage>(entity =>
+        {
+            entity.ToTable("SitePages");
+
+            entity.HasKey(e => e.Id);
+
+            entity.HasIndex(e => new { e.RoutePattern, e.HttpMethod })
+                .IsUnique();
+        });
     }
 
     #region SeedRoles: 기본 역할(Role)들을 생성하는 코드 중 하나 

--- a/src/VisualAcademy/VisualAcademy/Models/SitePage.cs
+++ b/src/VisualAcademy/VisualAcademy/Models/SitePage.cs
@@ -1,0 +1,30 @@
+﻿public class SitePage
+{
+    public long Id { get; set; }
+
+    public string RoutePattern { get; set; } = "";
+
+    public string? HttpMethod { get; set; }
+
+    public string? DisplayName { get; set; }
+
+    public string? PageTitle { get; set; }
+
+    public int? PageNumber { get; set; }
+
+    public int SortOrder { get; set; }
+
+    public bool IsPublic { get; set; }
+
+    public bool IsVisibleInDashboard { get; set; }
+
+    public string? RequiredRoles { get; set; }
+
+    public string? RequiredPolicy { get; set; }
+
+    public bool AllowAnonymous { get; set; }
+
+    public bool IsEndpointActive { get; set; }
+
+    public string Url => RoutePattern == "/" ? "/" : "/" + RoutePattern.TrimStart('/');
+}

--- a/src/VisualAcademy/VisualAcademy/Services/SitePageRouteSyncService.cs
+++ b/src/VisualAcademy/VisualAcademy/Services/SitePageRouteSyncService.cs
@@ -1,0 +1,88 @@
+﻿using Azunt.Web.Data;
+using Azunt.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Azunt.Web.Services;
+
+public class SitePageRouteSyncService
+{
+    private readonly IEnumerable<EndpointDataSource> _sources;
+    private readonly ApplicationDbContext _context;
+
+    public SitePageRouteSyncService(
+        IEnumerable<EndpointDataSource> sources,
+        ApplicationDbContext context)
+    {
+        _sources = sources;
+        _context = context;
+    }
+
+    public async Task SyncAsync()
+    {
+        var endpoints = _sources
+            .SelectMany(s => s.Endpoints)
+            .OfType<RouteEndpoint>();
+
+        var existing = await _context.SitePages.ToListAsync();
+
+        foreach (var page in existing)
+            page.IsEndpointActive = false;
+
+        foreach (var endpoint in endpoints)
+        {
+            var route = endpoint.RoutePattern.RawText;
+
+            if (string.IsNullOrWhiteSpace(route))
+                route = endpoint.RoutePattern.ToString();
+
+            if (string.IsNullOrWhiteSpace(route))
+                continue;
+
+            var methods = endpoint.Metadata
+                .GetMetadata<IHttpMethodMetadata>()?.HttpMethods
+                ?? new List<string> { "GET" };
+
+            var action = endpoint.Metadata
+                .GetMetadata<ControllerActionDescriptor>();
+
+            // 루트(/) 보정
+            if (action?.ControllerName == "Home" &&
+                action.ActionName == "Index")
+            {
+                route = "/";
+            }
+
+            var allowAnonymous =
+                endpoint.Metadata.GetMetadata<IAllowAnonymous>() != null;
+
+            foreach (var method in methods)
+            {
+                var found = existing.FirstOrDefault(x =>
+                    x.RoutePattern == route &&
+                    x.HttpMethod == method);
+
+                if (found == null)
+                {
+                    _context.SitePages.Add(new SitePage
+                    {
+                        RoutePattern = route,
+                        HttpMethod = method,
+                        DisplayName = action?.DisplayName,
+                        AllowAnonymous = allowAnonymous,
+                        IsEndpointActive = true
+                    });
+                }
+                else
+                {
+                    found.IsEndpointActive = true;
+                }
+            }
+        }
+
+        await _context.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
This PR adds a feature that automatically discovers all application routes using EndpointDataSource and stores them in a SitePages table for centralized management. It includes a basic admin UI to list, edit, and navigate pages, along with route synchronization logic that keeps database records aligned with active endpoints.